### PR TITLE
Typo when calling destroy

### DIFF
--- a/coffee/tooltip.coffee
+++ b/coffee/tooltip.coffee
@@ -34,7 +34,7 @@ class Tooltip
   remove: ->
     @drop.remove()
 
-  destory: ->
+  destroy: ->
     @drop.destroy()
 
   position: ->


### PR DESCRIPTION
Unless there is a naming conflict, I'm guessing this should be call `destroy`.
