### PR TITLE
Remove Compass and Ruby dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,6 @@ You will need:
 - Node.js/io.js & npm
 - Bower
 - Gulp
-- _Ruby_ (to be deprecated)
-- _Sass gem_ (to be deprecated)
-- _Compass gem_ (to be deprecated)
 
 
 ## Getting started
@@ -20,10 +17,6 @@ You will need:
    directory and running `npm run build`
 5. Assuming everything went well, you should now have a `dist` directory that
    matches the one you moved in step 4.
-6. __NOTE__: Depending on your local version of Sass and Compass, you may end up
-   with slightly different stylesheets. In most cases, the changes are
-   equivalents and nothing to worry about. That said, we are planning on
-   removing the Ruby dependencies to alleviate issues like this.
 
 
 ## Writing code!

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "tether-tooltip",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.hubspot.com/tooltip",
   "authors": [
     "Zack Bloom <zackbloom@gmail.com>",
@@ -25,7 +25,7 @@
     "tests"
   ],
   "dependencies": {
-    "drop": "~1.0.0",
-    "tether": "~0.7.1"
+    "tether": "~0.7.2",
+    "tether-drop": "~1.0.3"
   }
 }

--- a/dist/css/tooltip-theme-arrows.css
+++ b/dist/css/tooltip-theme-arrows.css
@@ -1,6 +1,4 @@
 .tooltip-element, .tooltip-element:after, .tooltip-element:before, .tooltip-element *, .tooltip-element *:after, .tooltip-element *:before {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box; }
 
 .tooltip-element {
@@ -13,8 +11,6 @@
   max-width: 100%;
   max-height: 100%; }
   .tooltip-element.tooltip-theme-arrows .tooltip-content {
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
     border-radius: 5px;
     position: relative;
     font-family: inherit;
@@ -110,8 +106,6 @@
       border-right-color: #000; }
 
 .tooltip-element.tooltip-theme-arrows {
-  -webkit-pointer-events: none;
-  -moz-pointer-events: none;
   pointer-events: none; }
   .tooltip-element.tooltip-theme-arrows .tooltip-content {
     padding: 0.5em 1em; }

--- a/dist/js/tooltip.js
+++ b/dist/js/tooltip.js
@@ -1,4 +1,4 @@
-/*! tether-tooltip 1.0.0 */
+/*! tether-tooltip 1.0.2 */
 
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,9 +3,10 @@ var gulp        = require('gulp');
 var babel       = require('gulp-babel');
 var bump        = require('gulp-bump');
 var filter      = require('gulp-filter');
-var sass        = require('gulp-ruby-sass');
 var header      = require('gulp-header');
+var prefixer    = require('gulp-autoprefixer');
 var rename      = require('gulp-rename');
+var sass        = require('gulp-sass');
 var uglify      = require('gulp-uglify');
 var tagVersion  = require('gulp-tag-version');
 var umd         = require('gulp-wrap-umd');
@@ -60,11 +61,12 @@ gulp.task('js', ['clean'], function() {
 
 // CSS
 gulp.task('css', function() {
-  sass('./src/css', {
-    loadPath: './bower_components',
-    compass: true
-  })
-  .pipe(gulp.dest(distDir + '/css'));
+  gulp.src('./src/css/**/*.sass')
+    .pipe(sass({
+      includePaths: ['./bower_components']
+    }))
+    .pipe(prefixer())
+    .pipe(gulp.dest(distDir + '/css'));
 });
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tether-tooltip",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CSS tooltips built on Tether",
   "authors": [
     "Adam Schwartz <adam.flynn.schwartz@gmail.com>",
@@ -18,18 +18,19 @@
   "devDependencies": {
     "del": "^1.1.1",
     "gulp": "^3.8.11",
+    "gulp-autoprefixer": "^2.2.0",
     "gulp-babel": "^5.1.0",
     "gulp-bump": "^0.3.0",
     "gulp-filter": "^2.0.2",
     "gulp-header": "^1.2.2",
     "gulp-rename": "^1.2.2",
-    "gulp-ruby-sass": "^1.0.5",
+    "gulp-sass": "^2.0.0",
     "gulp-tag-version": "^1.2.1",
     "gulp-uglify": "^1.2.0",
     "gulp-wrap-umd": "^0.2.1"
   },
   "dependencies": {
-    "tether": "^0.7.1",
-    "tether-drop": "^1.0.0"
+    "tether": "^0.7.2",
+    "tether-drop": "^1.0.3"
   }
 }

--- a/src/css/mixins/_pointer-events-temporary.sass
+++ b/src/css/mixins/_pointer-events-temporary.sass
@@ -1,4 +1,0 @@
-@mixin pointer-events($type: none)
-  -webkit-pointer-events: $type
-  -moz-pointer-events: $type
-  pointer-events: $type

--- a/src/css/tooltip-theme-arrows.sass
+++ b/src/css/tooltip-theme-arrows.sass
@@ -3,8 +3,6 @@
 @import ../bower_components/tether/sass/helpers/tether
 @import ../bower_components/tether/sass/helpers/tether-theme-arrows
 
-@import mixins/pointer-events-temporary
-
 $themePrefix: "tooltip"
 $arrowSize: 8px
 $backgroundColor: #000
@@ -17,7 +15,7 @@ $useDropShadow: false
 // Just a few additions
 
 .#{ $themePrefix }-element.#{ $themePrefix }-theme-arrows
-    +pointer-events(none)
+    pointer-events: none
 
     .#{ $themePrefix }-content
         padding: .5em 1em


### PR DESCRIPTION
__[Progress]__: Ready to merge. Sanity checking.

Removes Compass + Ruby dependencies by replacing `gulp-compass` with `gulp-autoprefixer` and `gulp-sass`. Nothing really needed `compass`, so remove the extra, fairly bloated dependency making it harder to comtribute if Ruby + Compass are not installed.

Depends on https://github.com/HubSpot/tether/pull/82 & https://github.com/HubSpot/drop/pull/74