### PR TITLE
Add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "scripts": {
     "build": "gulp build"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HubSpot/tooltip.git"
+  },
   "license": "MIT",
   "main": "dist/js/tooltip.js",
   "devDependencies": {


### PR DESCRIPTION
Was getting an `npm install` warning about no repository field.