### PR TITLE
Update main docs example

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -33,7 +33,7 @@ IE9+ and everything modern
 - Add `data-tooltip`, and optionally `data-tooltip-position` to any element.
 
 ```html
-<a href=# data-tooltip="Weeeeee" data-tooltip-position="top middle">I'm a link!</a>
+<a href=# data-tooltip="Weeeeee" data-tooltip-position="top center">I'm a link!</a>
 ```
 
 #### Manual Initialization


### PR DESCRIPTION
Changed the main example to read `top center` instead of `top middle`. `top middle` isn't an accepted parameter and so no 'v' caret is created. Example is on [main docs page](http://github.hubspot.com/tooltip/) under Usage.